### PR TITLE
feat: add custom 404 Not Found page with navigation to home

### DIFF
--- a/client/app/not-found.tsx
+++ b/client/app/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center text-white bg-background">
+      <div className="text-center">
+        <h1 className="text-9xl font-extrabold tracking-widest text-red-500">
+          404
+        </h1>
+        <div className="bg-red-500 px-3 py-1 text-sm rounded rotate-12 absolute">
+          Page Not Found
+        </div>
+        <p className="mt-6 text-lg text-gray-700">
+          Oops! The page you&apos;re looking for doesn&apos;t exist.
+        </p>
+        <Link href="/">
+          <button className="mt-8 px-6 py-3 text-sm font-semibold bg-red-600 rounded-lg hover:bg-red-700 transition">
+            Return Home
+          </button>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new `NotFound` component in the `client/app/not-found.tsx` file to handle 404 errors gracefully by displaying a user-friendly message and a link to return to the homepage.

Closes : #12 

Key changes:

* Added a new `NotFound` component that includes a styled 404 error message and a "Return Home" button linking back to the homepage.

### Video

https://github.com/user-attachments/assets/01cd0958-62bb-412c-8125-f4f7b86244d5

